### PR TITLE
Scopes: Re-purpose `isScope` as `isFunctionScope` for stack trace processing

### DIFF
--- a/proposals/scopes.md
+++ b/proposals/scopes.md
@@ -136,7 +136,11 @@ interface OriginalScope {
 interface GeneratedRange {
   start: GeneratedPosition;
   end: GeneratedPosition;
-  isScope: boolean;
+  /**
+   * If the generated range is a function/method/accessor in the generated JavaScript code (anything callable).
+   * Consumers use this to figure out which call frames to include/exclude when processing stack traces.
+   */
+  isFunctionScope: boolean;
   originalScope?: OriginalScope;
   /** If this scope corresponds to an inlined function body, record the callsite of the inlined function in the original code */
   callsite?: OriginalPosition;
@@ -228,7 +232,7 @@ Note: Each DATA represents one VLQ number.
   * Note: Unknown flags would skip the whole scope.
   * 0x1 has definition
   * 0x2 has callsite
-  * 0x4 is scope
+  * 0x4 is function scope
 * definition: (only existing if `has definition` flag is set)
   * DATA offset into `sources`
     * Note: This offset is relative to the offset of the last definition or absolute if this is the first definition


### PR DESCRIPTION
This PR renames `isScope` to `isFunctionScope`. The intention is to mark each generated range that is also something callable (functions, methods, arrow functions, accessors, constructors, ...). The purpose is twofold:

1. Stack trace processors can use this to figure out which call frames to show. The check basically becomes `range.isFunctionScope && !range.hasDefinition`. See #113 for a detailed discussions and also why a `isHidden` flag is not sufficient.
1. It makes inlining easier to figure out for stack trace processors: With this flag they can tell exactly at which generated range to stop expanding inlined frames.

Note that for 1. in particular this is a great boon for generators. If we don't have this flag then generators have to "mask" callsites for "hidden functions" instead. Which is a lot trickier especially if not all call-sites are known by a generator. Again, see #113 for an example/discussion.