### PR TITLE
Workflow: Auto-publish all branches to gh-pages

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -2,7 +2,8 @@ name: CI
 on:
   pull_request: {}
   push:
-    branches: [main, '2024']
+    branches-ignore:
+      - 'gh-pages'
 jobs:
   main:
     name: Build, Validate and Deploy
@@ -14,4 +15,4 @@ jobs:
           GH_PAGES_BRANCH: gh-pages
           TOOLCHAIN: bikeshed
           SOURCE: source-map.bs
-          DESTINATION: ${{ github.ref == 'refs/heads/2024' && '2024/index.html' || 'index.html' }}
+          DESTINATION: ${{ github.ref_name == 'main' && 'index.html' || format('{0}/index.html', github.ref_name) }}


### PR DESCRIPTION
This CL changes the auto publish workflow to build all branches (except `gh-pages`) and put the result into `<branch name>/index.html` on the `gh-pages` branch. The `main` branch is still published to the root `index.html` though.

This is very convenient for forks, since it's straight-forward to preview PRs.