### PR TITLE
Add aknowledgment for editorial changes in first Ecma edition

### DIFF
--- a/source-map.bs
+++ b/source-map.bs
@@ -177,6 +177,11 @@ Pavel Podivilov (Google).
 The source map format does not have version numbers anymore, and it is instead
 hard-coded to always be "3".
 
+In 2023-2024, the source map format was developed into a more precise Ecma standard,
+with significant contributions from many people, including Asumu Takikawa, Nicolò
+Ribaudo, and Jon Kuperman. Further iteration on the source map format is expected
+to come from TC39-TG4.
+
 <div style="display: none" id="copyright-before"></div>
 <div style="display: none" id="copyright">
 <p>COPYRIGHT NOTICE</p>

--- a/source-map.bs
+++ b/source-map.bs
@@ -178,9 +178,11 @@ The source map format does not have version numbers anymore, and it is instead
 hard-coded to always be "3".
 
 In 2023-2024, the source map format was developed into a more precise Ecma standard,
-with significant contributions from many people, including Asumu Takikawa, Nicolò
-Ribaudo, and Jon Kuperman. Further iteration on the source map format is expected
-to come from TC39-TG4.
+with significant contributions from many people. Further iteration on the source map
+format is expected to come from TC39-TG4.
+
+Asumu Takikawa, Nicolò Ribaudo, Jon Kuperman
+ECMA-426, 1<sup>st</sup> edition, Project Editors
 
 <div style="display: none" id="copyright-before"></div>
 <div style="display: none" id="copyright">


### PR DESCRIPTION
This was suggested on Matrix by other delegates with more Ecma experience than us, highlighting that the work Jon and I have been doing in the past months to get the spec to a good Ecma state is similar to an editor's role, even without being officially editors.

I copied the way of listing editor names from ECMA-262 and ECMA-402 (as "signatures" at the end of the introduction).