### PR TITLE
Editorial: Use grammar for VLQ and Mappings and decode via SDO

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -765,13 +765,13 @@
 
       <emu-grammar type="definition">
         MappingsField :
-          SegmentList
+          LineList
 
-        SegmentList :
-          Segment
-          Segment `;` SegmentList
+        LineList :
+          Line
+          Line `;` LineList
 
-        Segment :
+        Line :
           MappingList?
 
         MappingList :
@@ -849,26 +849,22 @@
         </h1>
         <dl class="header"></dl>
         <emu-grammar>
-          SegmentList :
-            Segment `;` SegmentList
-
+          LineList :
+            Line `;` LineList
+        </emu-grammar>
+        <emu-alg>
+          1. Perform DecodeMappingsField of |Line| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Set _state_.[[GeneratedLine]] to _state_.[[GeneratedLine]] + 1.
+          1. Set _state_.[[GeneratedColumn]] to 0.
+          1. Perform DecodeMappingsField of |LineList| with arguments _state_, _mappings_, _names_ and _sources_.
+        </emu-alg>
+        <emu-grammar>
           MappingList :
             Mapping `,` MappingList
         </emu-grammar>
         <emu-alg>
-          1. For each child node _child_ of this Parse Node, do
-            1. If _child_ is an instance of a nonterminal, then
-              1. Perform DecodeMappingsField of _child_ with arguments _state_, _mappings_, _names_ and _sources_.
-        </emu-alg>
-        <emu-grammar>
-          Segment :
-            MappingList?
-        </emu-grammar>
-        <emu-alg>
-          1. Set _state_.[[GeneratedLine]] to _state_.[[GeneratedLine]] + 1.
-          1. Set _state_.[[GeneratedColumn]] to 0.
-          1. If |MappingList| is present, then
-            1. Perform DecodeMappingsField on |MappingList| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsField of |Mapping| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsField of |MappingList| with arguments _state_, _mappings_, _names_ and _sources_.
         </emu-alg>
         <emu-grammar>
           Mapping :

--- a/spec.emu
+++ b/spec.emu
@@ -770,20 +770,19 @@
       <p>The mappings String must adhere to the following grammar:</p>
 
       <emu-grammar type="definition">
-        Mappings :
-          SemicolonList? Segment SemicolonList?
+        MappingsField :
+          SegmentList
+
+        SegmentList :
+          Segment
+          Segment `;` SegmentList
 
         Segment :
-          MappingList
-          MappingList SemicolonList Segment
+          MappingList?
 
         MappingList :
           Mapping
-          MappingList `,` Mapping
-
-        SemicolonList :
-          `;`
-          SemicolonList `;`
+          Mapping `,` MappingList
 
         Mapping :
           GeneratedColumn
@@ -845,9 +844,9 @@
         </table>
       </emu-table>
 
-      <emu-clause id="sec-DecodeMappingsSdo" type="sdo">
+      <emu-clause id="sec-DecodeMappingsField" type="sdo">
         <h1>
-          DecodeMappingsSdo (
+          DecodeMappingsField (
             _state_: a Decode Mapping State Record,
             _mappings_: a List of Decoded Mapping Records,
             _names_: a List of Strings,
@@ -856,28 +855,33 @@
         </h1>
         <dl class="header"></dl>
         <emu-grammar>
-          Mappings :
-            SemicolonList? Segment SemicolonList?
-
-          Segment :
-            MappingList
-            MappingList SemicolonList Segment
+          SegmentList :
+            Segment `;` SegmentList
 
           MappingList :
-            Mapping
-            MappingList `,` Mapping
+            Mapping `,` MappingList
         </emu-grammar>
         <emu-alg>
           1. For each child node _child_ of this Parse Node, do
             1. If _child_ is an instance of a nonterminal, then
-              1. Perform DecodeMappingsSdo of _child_ with arguments _state_, _mappings_, _names_ and _sources_.
+              1. Perform DecodeMappingsField of _child_ with arguments _state_, _mappings_, _names_ and _sources_.
+        </emu-alg>
+        <emu-grammar>
+          Segment :
+            MappingList?
+        </emu-grammar>
+        <emu-alg>
+          1. Set _state_.[[GeneratedLine]] to _state_.[[GeneratedLine]] + 1.
+          1. Set _state_.[[GeneratedColumn]] to 0.
+          1. If |MappingList| is present, then
+            1. Perform DecodeMappingsField on |MappingList| with arguments _state_, _mappings_, _names_ and _sources_.
         </emu-alg>
         <emu-grammar>
           Mapping :
             GeneratedColumn
         </emu-grammar>
         <emu-alg>
-          1. Perform DecodeMappingsSdo of |GeneratedColumn| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsField of |GeneratedColumn| with arguments _state_, _mappings_, _names_ and _sources_.
           1. Let _decodedMapping_ be a new DecodedMappingRecord { [[GeneratedLine]]: _state_.[[GeneratedLine]], [[GeneratedColumn]]: _state_.[[GeneratedColumn]], [[OriginalSource]]: *null*, [[OriginalLine]]: *null*, [[OriginalColumn]]: *null*, [[Name]]: *null* }.
           1. Append _decodedMapping_ to _mappings_.
         </emu-alg>
@@ -886,28 +890,17 @@
             GeneratedColumn OriginalSource OriginalLine OriginalColumn Name?
         </emu-grammar>
         <emu-alg>
-          1. Perform DecodeMappingsSdo of |GeneratedColumn| with arguments _state_, _mappings_, _names_ and _sources_.
-          1. Perform DecodeMappingsSdo of |OriginalSource| with arguments _state_, _mappings_, _names_ and _sources_.
-          1. Perform DecodeMappingsSdo of |OriginalLine| with arguments _state_, _mappings_, _names_ and _sources_.
-          1. Perform DecodeMappingsSdo of |OriginalColumn| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsField of |GeneratedColumn| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsField of |OriginalSource| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsField of |OriginalLine| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsField of |OriginalColumn| with arguments _state_, _mappings_, _names_ and _sources_.
           1. Let _source_ be _sources_[_state_.[[SourceIndex]]].
           1. If |Name| is present, then
-            1. Perform DecodeMappingsSdo of |Name| with arguments _state_, _mappings_, _names_ and _sources_.
+            1. Perform DecodeMappingsField of |Name| with arguments _state_, _mappings_, _names_ and _sources_.
             1. Let _name_ be _names_[_state_.[[NameIndex]]].
           1. Else, let _name_ be *null*.
           1. Let _decodedMapping_ be a new DecodedMappingRecord { [[GeneratedLine]]: _state_.[[GeneratedLine]], [[GeneratedColumn]]: _state_.[[GeneratedColumn]], [[OriginalSource]]: _source_, [[OriginalLine]]: _state_.[[OriginalLine]], [[OriginalColumn]]: _state_.[[OriginalColumn]], [[Name]]: _name_ }.
           1. Append _decodedMapping_ to _mappings_.
-        </emu-alg>
-        <emu-grammar>
-          SemicolonList :
-            `;`
-            SemicolonList `;`
-        </emu-grammar>
-        <emu-alg>
-          1. Set _state_.[[GeneratedLine]] to _state_.[[GeneratedLine]] + 1.
-          1. Set _state_.[[GeneratedColumn]] to 0.
-          1. If |SemicolonList| is present, then
-            1. Perform DecodeMappingsSdo on |SemicolonList| with arguments _state_, _mappings_, _names_ and _sources_.
         </emu-alg>
         <emu-grammar>
           GeneratedColumn :
@@ -968,12 +961,12 @@
       <dl class="header"></dl>
       <emu-alg>
         1. Let _mappings_ be a new empty List.
-        1. Let _mappingsNode_ be the root Parse Node when parsing _rawMappings_ using |Mappings| as the goal symbol.
+        1. Let _mappingsNode_ be the root Parse Node when parsing _rawMappings_ using |MappingsField| as the goal symbol.
         1. If parsing failed, then
           1. Optionally report an error.
           1. Return _mappings_.
         1. Let _state_ be a new Decode Mapping State Record with all fields set to 0.
-        1. Perform DecodeMappingsSdo of _mappingsNode_ with arguments _state_, _mappings_, _names_ and _sources_.
+        1. Perform DecodeMappingsField of _mappingsNode_ with arguments _state_, _mappings_, _names_ and _sources_.
         1. Return _mappings_.
       </emu-alg>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -890,10 +890,10 @@
           1. Perform DecodeMappingsSdo of |OriginalSource| with arguments _state_, _mappings_, _names_ and _sources_.
           1. Perform DecodeMappingsSdo of |OriginalLine| with arguments _state_, _mappings_, _names_ and _sources_.
           1. Perform DecodeMappingsSdo of |OriginalColumn| with arguments _state_, _mappings_, _names_ and _sources_.
-          1. Let _source_ be _sources_.[_state_.[[SourceIndex]]].
+          1. Let _source_ be _sources_[_state_.[[SourceIndex]]].
           1. If |Name| is present, then
             1. Perform DecodeMappingsSdo of |Name| with arguments _state_, _mappings_, _names_ and _sources_.
-            1. Let _name_ be _names_.[_state_.[[NameIndex]]].
+            1. Let _name_ be _names_[_state_.[[NameIndex]]].
           1. Else, let _name_ be *null*.
           1. Let _decodedMapping_ be a new DecodedMappingRecord { [[GeneratedLine]]: _state_.[[GeneratedLine]], [[GeneratedColumn]]: _state_.[[GeneratedColumn]], [[OriginalSource]]: _source_, [[OriginalLine]]: _state_.[[OriginalLine]], [[OriginalColumn]]: _state_.[[OriginalColumn]], [[Name]]: _name_ }.
           1. Append _decodedMapping_ to _mappings_.

--- a/spec.emu
+++ b/spec.emu
@@ -236,6 +236,15 @@
       <p>An implementation can choose different behaviors for different optional errors.</p>
     </emu-clause>
   </emu-clause>
+
+  <emu-clause id="sec-grammar-notation">
+    <h1>Grammar Notation</h1>
+    <p>This specification follows the same grammar notation convention as defined by <a href="https://tc39.es/ecma262/#sec-grammar-notation">ECMA-262 (Grammar Notation)</a>, with the following caveats:</p>
+    <ul>
+      <li>The terminal symbols of grammars in this specification are individual code points. They are more like ECMA-262 lexical and regexp grammars than the ECMA-262 syntactic grammar.</li>
+      <li>This specification does not use <a href="https://tc39.es/ecma262/#sec-grammatical-parameters">grammatical parameters</a> or <a href="https://tc39.es/ecma262/#sec-lookahead-restrictions">lookahead restrictions</a>, which keeps the grammars simpler.</li>
+    </ul>
+  </emu-clause>
 </emu-clause>
 
 <emu-clause id="sec-terms-and-definitions">

--- a/spec.emu
+++ b/spec.emu
@@ -290,23 +290,13 @@
         ContinuationDigit VlqDigitList
 
       TerminalDigit ::
-        OneOfTerminalDigit
-
-      ContinuationDigit ::
-        OneOfContinuationDigit
-
-      OneOfTerminalDigit :: one of
         `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R`
         `S` `T` `U` `V` `W` `X` `Y` `Z` `a` `b` `c` `d` `e` `f`
 
-      OneOfContinuationDigit :: one of
+      ContinuationDigit ::
         `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x`
         `y` `z` `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `+` `/`
     </emu-grammar>
-
-    <emu-note type="editor">
-      |OneOfTerminalDigit| and |OneOfContinuationDigit| will go away and are only present in the preview draft. They are here because ecmarkup currently does not support *one of* productions in SDOs.
-    </emu-note>
 
     <emu-clause id="sec-VLQSignedValue" type="sdo">
       <h1>VLQSignedValue ( ): an integer</h1>
@@ -346,7 +336,9 @@
         1. Return _left_ + _right_ × 2<sup>5</sup>.
       </emu-alg>
       <emu-grammar>
-        TerminalDigit :: OneOfTerminalDigit
+        TerminalDigit ::
+          `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R`
+          `S` `T` `U` `V` `W` `X` `Y` `Z` `a` `b` `c` `d` `e` `f`
       </emu-grammar>
       <emu-alg>
         1. Let _digit_ be the character matched by this production.
@@ -355,7 +347,9 @@
         1. Return _value_.
       </emu-alg>
       <emu-grammar>
-        ContinuationDigit :: OneOfContinuationDigit
+        ContinuationDigit ::
+          `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x`
+          `y` `z` `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `+` `/`
       </emu-grammar>
       <emu-alg>
         1. Let _digit_ be the character matched by this production.

--- a/spec.emu
+++ b/spec.emu
@@ -304,7 +304,7 @@
         `y` `z` `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `+` `/`
     </emu-grammar>
 
-    <emu-note>
+    <emu-note type="editor">
       |OneOfTerminalDigit| and |OneOfContinuationDigit| will go away and are only present in the preview draft. They are here because ecmarkup currently does not support *one of* productions in SDOs.
     </emu-note>
 
@@ -318,7 +318,10 @@
         1. Let _unsigned_ be the VLQUnsignedValue of |VlqDigitList|.
         1. If _unsigned_ modulo 2 = 1, let _sign_ be -1.
         1. Else, let _sign_ be 1.
-        1. Return _sign_ × floor(_unsigned_ / 2).
+        1. Let _value_ be floor(_unsigned_ / 2).
+        1. If _value_ is 0 and _sign_ is -1, return -2<sup>31</sup>.
+        1. If _value_ is ≥ 2<sup>31</sup>, throw an error.
+        1. Return _sign_ × _value_.
       </emu-alg>
     </emu-clause>
 
@@ -326,11 +329,12 @@
       <h1>VLQUnsignedValue ( ): an non-negative integer</h1>
       <dl class="header"></dl>
       <emu-grammar>
-        VlqDigitList ::
-          TerminalDigit
+        Vlq :: VlqDigitList
       </emu-grammar>
       <emu-alg>
-        1. Return VLQUnsignedValue of |TerminalDigit|.
+        1. Let _value_ be the VLQUnsignedValue of |VlqDigitList|.
+        1. If _value_ is ≥ 2<sup>31</sup>, throw an error.
+        1. Return _value_.
       </emu-alg>
       <emu-grammar>
         VlqDigitList ::

--- a/spec.emu
+++ b/spec.emu
@@ -804,7 +804,7 @@
           Vlq
       </emu-grammar>
 
-      <p>A <dfn id="decode-mapping-state-record" variants="Decode Mapping State Records">Decoded Mapping State Record</dfn> has the following fields:</p>
+      <p>A <dfn id="decode-mapping-state-record" variants="Decode Mapping State Records">Decode Mapping State Record</dfn> has the following fields:</p>
       <emu-table id="table-decode-mapping-state-fields" caption="Fields of Decode Mapping State Records">
         <table>
           <thead>
@@ -918,7 +918,7 @@
         <emu-alg>
           1. Let _relativeSourceIndex_ the VLQSignedValue of |Vlq|.
           1. Set _state_.[[SourceIndex]] to _state_.[[SourceIndex]] + _relativeSourceIndex_.
-          1. If _state_.[[SourceIndex]] &lt; 0 or _state.[[SourceIndex]] ≥ the number of elements of _sources_, optionally report an error.
+          1. If _state_.[[SourceIndex]] &lt; 0 or _state_.[[SourceIndex]] ≥ the number of elements of _sources_, optionally report an error.
         </emu-alg>
         <emu-grammar>
           OriginalLine :

--- a/spec.emu
+++ b/spec.emu
@@ -882,6 +882,9 @@
         </emu-grammar>
         <emu-alg>
           1. Perform DecodeMappingsField of |GeneratedColumn| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. If _state_.[[GeneratedColumn]] &lt; 0, then
+            1. Optionally report an error.
+            1. Return.
           1. Let _decodedMapping_ be a new DecodedMappingRecord { [[GeneratedLine]]: _state_.[[GeneratedLine]], [[GeneratedColumn]]: _state_.[[GeneratedColumn]], [[OriginalSource]]: *null*, [[OriginalLine]]: *null*, [[OriginalColumn]]: *null*, [[Name]]: *null* }.
           1. Append _decodedMapping_ to _mappings_.
         </emu-alg>
@@ -891,15 +894,30 @@
         </emu-grammar>
         <emu-alg>
           1. Perform DecodeMappingsField of |GeneratedColumn| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. If _state_.[[GeneratedColumn]] &lt; 0, then
+            1. Optionally report an error.
+            1. Return.
           1. Perform DecodeMappingsField of |OriginalSource| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. If _state_.[[SourceIndex]] &lt; 0 or _state_.[[SourceIndex]] ≥ the number of elements of _sources_, then
+            1. Optionally report an error.
+            1. Let _source_ be *null*.
+          1. Else, let _source_ be _sources_[_state_.[[SourceIndex]]].
           1. Perform DecodeMappingsField of |OriginalLine| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. If _state_.[[OriginalLine]] &lt; 0, then
+            1. Optionally report an error.
+            1. Let _originalLine_ be *null*.
+          1. Else, let _originalLine_ be _state_.[[OriginalLine]].
           1. Perform DecodeMappingsField of |OriginalColumn| with arguments _state_, _mappings_, _names_ and _sources_.
-          1. Let _source_ be _sources_[_state_.[[SourceIndex]]].
+          1. If _state_.[[OriginalColumn]] &lt; 0, then
+            1. Optionally report an error.
+            1. Let _originalColumn_ be *null*.
+          1. Else, let _originalColumn_ be _state_.[[OriginalColumn]].
+          1. Let _name_ be *null*.
           1. If |Name| is present, then
             1. Perform DecodeMappingsField of |Name| with arguments _state_, _mappings_, _names_ and _sources_.
-            1. Let _name_ be _names_[_state_.[[NameIndex]]].
-          1. Else, let _name_ be *null*.
-          1. Let _decodedMapping_ be a new DecodedMappingRecord { [[GeneratedLine]]: _state_.[[GeneratedLine]], [[GeneratedColumn]]: _state_.[[GeneratedColumn]], [[OriginalSource]]: _source_, [[OriginalLine]]: _state_.[[OriginalLine]], [[OriginalColumn]]: _state_.[[OriginalColumn]], [[Name]]: _name_ }.
+            1. If _state_.[[NameIndex]] &lt; 0 or _state_.[[NameIndex]] ≥ the number of elements of _sources_, optionally report an error.
+            1. Else, set _name_ to _names_[_state_.[[NameIndex]]].
+          1. Let _decodedMapping_ be a new DecodedMappingRecord { [[GeneratedLine]]: _state_.[[GeneratedLine]], [[GeneratedColumn]]: _state_.[[GeneratedColumn]], [[OriginalSource]]: _source_, [[OriginalLine]]: _originalLine_, [[OriginalColumn]]: _originalColumn_, [[Name]]: _name_ }.
           1. Append _decodedMapping_ to _mappings_.
         </emu-alg>
         <emu-grammar>
@@ -909,7 +927,6 @@
         <emu-alg>
           1. Let _relativeColumn_ be the VLQSignedValue of |Vlq|.
           1. Set _state_.[[GeneratedColumn]] to _state_.[[GeneratedColumn]] + _relativeColumn_.
-          1. If _state_.[[GeneratedColumn]] &lt; 0, optionally report an error.
         </emu-alg>
         <emu-grammar>
           OriginalSource :
@@ -918,7 +935,6 @@
         <emu-alg>
           1. Let _relativeSourceIndex_ the VLQSignedValue of |Vlq|.
           1. Set _state_.[[SourceIndex]] to _state_.[[SourceIndex]] + _relativeSourceIndex_.
-          1. If _state_.[[SourceIndex]] &lt; 0 or _state_.[[SourceIndex]] ≥ the number of elements of _sources_, optionally report an error.
         </emu-alg>
         <emu-grammar>
           OriginalLine :
@@ -927,7 +943,6 @@
         <emu-alg>
           1. Let _relativeLine_ be the VLQSignedValue of |Vlq|.
           1. Set _state_.[[OriginalLine]] to _state_.[[OriginalLine]] + _relativeLine_.
-          1. If _state_.[[OriginalLine]] &lt; 0, optionally report an error.
         </emu-alg>
         <emu-grammar>
           OriginalColumn :
@@ -936,7 +951,6 @@
         <emu-alg>
           1. Let _relativeColumn_ be the VLQSignedValue of |Vlq|.
           1. Set _state_.[[OriginalColumn]] to _state_.[[OriginalColumn]] + _relativeColumn_.
-          1. If _state_.[[OriginalColumn]] &lt; 0, optionally report an error.
         </emu-alg>
         <emu-grammar>
           Name :
@@ -945,7 +959,6 @@
         <emu-alg>
           1. Let _relativeName_ be the VLQSignedValue of |Vlq|.
           1. Set _state_.[[NameIndex]] to _state_.[[NameIndex]] + _relativeName_.
-          1. If _state_.[[NameIndex]] &lt; 0 or _state_.[[NameIndex]] ≥ the number of elements of _sources_, optionally report an error.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -286,80 +286,78 @@
         VlqDigitList
 
       VlqDigitList ::
-        DigitWithoutContinuationBit
-        DigitWithContinuationBit VlqDigitList
+        TerminalDigit
+        ContinuationDigit VlqDigitList
 
-      DigitWithoutContinuationBit :: one of
+      TerminalDigit ::
+        OneOfTerminalDigit
+
+      ContinuationDigit ::
+        OneOfContinuationDigit
+
+      OneOfTerminalDigit :: one of
         `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R`
         `S` `T` `U` `V` `W` `X` `Y` `Z` `a` `b` `c` `d` `e` `f`
 
-      DigitWithContinuationBit :: one of
+      OneOfContinuationDigit :: one of
         `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x`
         `y` `z` `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `+` `/`
     </emu-grammar>
 
-    <emu-clause id="sec-DecodeSignedBase64VLQ" type="abstract operation">
-      <h1>
-        DecodeSignedBase64VLQ (
-          _vlq_: a |Vlq| Parse Node,
-        ): an integer
-      </h1>
+    <emu-note>
+      |OneOfTerminalDigit| and |OneOfContinuationDigit| will go away and are only present in the preview draft. They are here because ecmarkup currently does not support *one of* productions in SDOs.
+    </emu-note>
+
+    <emu-clause id="sec-VLQSignedValue" type="sdo">
+      <h1>VLQSignedValue ( ): an integer</h1>
       <dl class="header"></dl>
+      <emu-grammar>
+        Vlq :: VlqDigitList
+      </emu-grammar>
       <emu-alg>
-        1. Let _accumulator_ be a new record { [[Value]]: 0, [[Shift]]: 0 }.
-        1. Perform DecodeBase64VLQ of _vlq_ with arguments _accumulator_.
-        1. If _accumulator_.[[Value]] modulo 2 = 1, let _sign_ be -1.
+        1. Let _unsigned_ be the VLQUnsignedValue of |VlqDigitList|.
+        1. If _unsigned_ modulo 2 = 1, let _sign_ be -1.
         1. Else, let _sign_ be 1.
-        1. Let _result_ to _accumulator_.[[Value]] / 2.
-        1. Return _result_ * _sign_.
+        1. Return _sign_ × floor(_unsigned_ / 2).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-DecodeBase64VLQ" type="sdo">
-      <h1>
-        DecodeBase64VLQ (
-          _accumulator_: a Record with an integer [[Value]] field and a non-negative integer [[Shift]] field,
-        )
-      </h1>
+    <emu-clause id="sec-VLQUnsignedValue" type="sdo">
+      <h1>VLQUnsignedValue ( ): an non-negative integer</h1>
       <dl class="header"></dl>
       <emu-grammar>
         VlqDigitList ::
-          DigitWithoutContinuationBit
+          TerminalDigit
       </emu-grammar>
       <emu-alg>
-        1. Let _byte_ be DecodeBase64Digit(|DigitWithoutContinuationBit|).
-        1. Assert: _byte_ &lt; 32.
-        1. Set _accumulator_.[[Value]] to _accumulator_.[[Value]] + _byte_ × 2<sup>_accumulator_.[[Shift]]</sup>.
-        1. If _accumulator_.[[Value]] ≥ 2<sup>31</sup>, throw an error.
-        1. Set _accumulator_.[[Shift]] to _accumulator_.[[Shift]] × 2<sup>5</sup>.
+        1. Return VLQUnsignedValue of |TerminalDigit|.
       </emu-alg>
       <emu-grammar>
         VlqDigitList ::
-          DigitWithContinuationBit VlqDigitList
+          ContinuationDigit VlqDigitList
       </emu-grammar>
       <emu-alg>
-        1. Let _byte_ be DecodeBase64Digit(|DigitWithContinuationBit|).
-        1. Assert: _byte_ ≥ 32 and _byte_ &lt; 64.
-        1. Set _byte_ to floor(_byte_ / 32).
-        1. Set _accumulator_.[[Value]] to _accumulator_.[[Value]] + _byte_ × 2<sup>_accumulator_.[[Shift]]</sup>.
-        1. If _accumulator_.[[Value]] ≥ 2<sup>31</sup>, throw an error.
-        1. Set _accumulator_.[[Shift]] to _accumulator_.[[Shift]] × 2<sup>5</sup>.
-        1. Perform DecodeBase64VLQ of |VlqDigitList| with argument _accumulator_.
+        1. Let _left_ be the VLQUnsignedValue of |ContinuationDigit|.
+        1. Let _right_ be the VLQUnsignedValue of |VlqDigitList|.
+        1. Return _left_ + _right_ × 2<sup>5</sup>.
       </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-DecodeBase64Digit" type="abstract operation">
-      <h1>
-        DecodeBase64Digit (
-          _digit_: a |DigitWithoutContinuationBit| or a |DigitWithContinuationBit| Parse Node,
-        ): an integer
-      </h1>
-      <dl class="header"></dl>
+      <emu-grammar>
+        TerminalDigit :: OneOfTerminalDigit
+      </emu-grammar>
       <emu-alg>
-        1. Assert: The source text matched by _digit_ is a valid <emu-xref href="#sec-references-informative">base64</emu-xref> character as defined by IETF RFC 4648.
-        1. Let _value_ be the integer corresponding to the source text matched by _digit_, according to the <emu-xref href="#sec-references-informative">base64</emu-xref> encoding as defined by IETF RFC 4648.
-        1. Assert: _value_ &lt; 2<sup>6</sup>.
+        1. Let _digit_ be the character matched by this production.
+        1. Let _value_ be the integer corresponding to _digit_, according to the <emu-xref href="#sec-references-informative">base64</emu-xref> encoding as defined by IETF RFC 4648.
+        1. Assert: _value_ &lt; 32.
         1. Return _value_.
+      </emu-alg>
+      <emu-grammar>
+        ContinuationDigit :: OneOfContinuationDigit
+      </emu-grammar>
+      <emu-alg>
+        1. Let _digit_ be the character matched by this production.
+        1. Let _value_ be the integer corresponding to _digit_, according to the <emu-xref href="#sec-references-informative">base64</emu-xref> encoding as defined by IETF RFC 4648.
+        1. Assert: 32 ≤ _value_ &lt; 64.
+        1. Return _value_ - 32.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -912,7 +910,7 @@
             Vlq
         </emu-grammar>
         <emu-alg>
-          1. Let _relativeColumn_ be DecodeBase64VLQ(|Vlq|).
+          1. Let _relativeColumn_ be the VLQSignedValue of |Vlq|.
           1. Set _state_.[[GeneratedColumn]] to _state_.[[GeneratedColumn]] + _relativeColumn_.
           1. If _state_.[[GeneratedColumn]] &lt; 0, optionally report an error.
         </emu-alg>
@@ -921,7 +919,7 @@
             Vlq
         </emu-grammar>
         <emu-alg>
-          1. Let _relativeSourceIndex_ be DecodeBase64VLQ(|Vlq|).
+          1. Let _relativeSourceIndex_ the VLQSignedValue of |Vlq|.
           1. Set _state_.[[SourceIndex]] to _state_.[[SourceIndex]] + _relativeSourceIndex_.
           1. If _state_.[[SourceIndex]] &lt; 0 or _state.[[SourceIndex]] ≥ the number of elements of _sources_, optionally report an error.
         </emu-alg>
@@ -930,7 +928,7 @@
             Vlq
         </emu-grammar>
         <emu-alg>
-          1. Let _relativeLine_ be DecodeBase64VLQ(|Vlq|).
+          1. Let _relativeLine_ be the VLQSignedValue of |Vlq|.
           1. Set _state_.[[OriginalLine]] to _state_.[[OriginalLine]] + _relativeLine_.
           1. If _state_.[[OriginalLine]] &lt; 0, optionally report an error.
         </emu-alg>
@@ -939,7 +937,7 @@
             Vlq
         </emu-grammar>
         <emu-alg>
-          1. Let _relativeColumn_ be DecodeBase64VLQ(|Vlq|).
+          1. Let _relativeColumn_ be the VLQSignedValue of |Vlq|.
           1. Set _state_.[[OriginalColumn]] to _state_.[[OriginalColumn]] + _relativeColumn_.
           1. If _state_.[[OriginalColumn]] &lt; 0, optionally report an error.
         </emu-alg>
@@ -948,7 +946,7 @@
             Vlq
         </emu-grammar>
         <emu-alg>
-          1. Let _relativeName_ be DecodeBase64VLQ(|Vlq|).
+          1. Let _relativeName_ be the VLQSignedValue of |Vlq|.
           1. Set _state_.[[NameIndex]] to _state_.[[NameIndex]] + _relativeName_.
           1. If _state_.[[NameIndex]] &lt; 0 or _state_[[NameIndex]] ≥ the number of elements of _sources_, optionally report an error.
         </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -253,18 +253,6 @@
       <p>source code which has not been passed through a compiler or transpiler.</p>
     </dd>
 
-    <dt><dfn id="sec-terms-and-definitions-base64-vlq">base64 VLQ</dfn></dt>
-    <dd>
-      <p>a <emu-xref href="#sec-references-informative">base64</emu-xref>-encoded variable-length quantity, where the most significant bit (the 6th bit) is used as the continuation bit, and the "digits" are encoded into the string least significant first, and where the least significant bit of the first digit is used as the sign bit.</p>
-      <emu-note>The values that can be represented by the base64 VLQ encoding are limited to 32-bit quantities until some use case for larger values is presented. This means that values exceeding 32-bits are invalid and implementations may reject them. The sign bit is counted towards the limit, but the continuation bits are not.</emu-note>
-      <emu-note example>
-        The string `"iB"` represents a base64 VLQ with two digits. The first digit `"i"` encodes the bit pattern `0x100010`, which has a continuation bit of `1` (the VLQ continues), a sign bit of `0` (non-negative), and the value bits `0x0001`. The second digit `B` encodes the bit pattern `0x000001`, which has a continuation bit of `0`, no sign bit, and value bits `0x00001`. The decoding of this VLQ string is the number 17.
-      </emu-note>
-      <emu-note example>
-        The string `"V"` represents a base64 VLQ with one digit. The digit `"V"` encodes the bit pattern `0x010101`, which has a continuation bit of `0` (no continuation), a sign bit of `1` (negative), and the value bits `0x1010`. The decoding of this VLQ string is the number -10.
-      </emu-note>
-    </dd>
-
     <dt><dfn id="sec-terms-and-definitions-source-mapping-url">source map URL</dfn></dt>
     <dd>
       <p>URL referencing the location of a source map from the generated code.</p>
@@ -276,91 +264,99 @@
       <emu-note>That means that "A" (`LATIN CAPITAL LETTER A`) measures as 1 code unit, and "🔥" (`FIRE`) measures as 2 code units. Source maps for other content types may diverge from this.</emu-note>
     </dd>
   </dl>
+</emu-clause>
 
-  <emu-clause id="sec-vlq-grammar">
-    <h1>base64 VLQ grammar</h1>
-    <p>A base64-encoded variable-length quantity adheres to the following lexical grammar:</p>
+<emu-clause id="sec-base64-vlq">
+  <h1>base64 VLQ</h1>
+  <p>A <dfn id="sec-base64-vlq">base64 VLQ</dfn> is a <emu-xref href="#sec-references-informative">base64</emu-xref>-encoded variable-length quantity, where the most significant bit (the 6th bit) is used as the continuation bit, and the "digits" are encoded into the string least significant first, and where the least significant bit of the first digit is used as the sign bit.</p>
+  <emu-note>The values that can be represented by the base64 VLQ encoding are limited to 32-bit quantities until some use case for larger values is presented. This means that values exceeding 32-bits are invalid and implementations may reject them. The sign bit is counted towards the limit, but the continuation bits are not.</emu-note>
+  <emu-note example>
+    The string `"iB"` represents a base64 VLQ with two digits. The first digit `"i"` encodes the bit pattern `0x100010`, which has a continuation bit of `1` (the VLQ continues), a sign bit of `0` (non-negative), and the value bits `0x0001`. The second digit `B` encodes the bit pattern `0x000001`, which has a continuation bit of `0`, no sign bit, and value bits `0x00001`. The decoding of this VLQ string is the number 17.
+  </emu-note>
+  <emu-note example>
+    The string `"V"` represents a base64 VLQ with one digit. The digit `"V"` encodes the bit pattern `0x010101`, which has a continuation bit of `0` (no continuation), a sign bit of `1` (negative), and the value bits `0x1010`. The decoding of this VLQ string is the number -10.
+  </emu-note>
+  <p>A base64 VLQ adheres to the following lexical grammar:</p>
 
-    <emu-grammar type="definition">
-      Vlq ::
-        VlqDigitList
+  <emu-grammar type="definition">
+    Vlq ::
+      VlqDigitList
 
+    VlqDigitList ::
+      TerminalDigit
+      ContinuationDigit VlqDigitList
+
+    TerminalDigit ::
+      `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R`
+      `S` `T` `U` `V` `W` `X` `Y` `Z` `a` `b` `c` `d` `e` `f`
+
+    ContinuationDigit ::
+      `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x`
+      `y` `z` `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `+` `/`
+  </emu-grammar>
+
+  <emu-clause id="sec-VLQSignedValue" type="sdo">
+    <h1>VLQSignedValue ( ): an integer</h1>
+    <dl class="header"></dl>
+    <emu-grammar>
+      Vlq :: VlqDigitList
+    </emu-grammar>
+    <emu-alg>
+      1. Let _unsigned_ be the VLQUnsignedValue of |VlqDigitList|.
+      1. If _unsigned_ modulo 2 = 1, let _sign_ be -1.
+      1. Else, let _sign_ be 1.
+      1. Let _value_ be floor(_unsigned_ / 2).
+      1. If _value_ is 0 and _sign_ is -1, return -2<sup>31</sup>.
+      1. If _value_ is ≥ 2<sup>31</sup>, throw an error.
+        <emu-note>
+          The check is required here as _unsigned_ is the VLQUnsignedValue of |VlqDigitList|, not of |Vlq|.
+        </emu-note>
+      1. Return _sign_ × _value_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-VLQUnsignedValue" type="sdo">
+    <h1>VLQUnsignedValue ( ): an non-negative integer</h1>
+    <dl class="header"></dl>
+    <emu-grammar>
+      Vlq :: VlqDigitList
+    </emu-grammar>
+    <emu-alg>
+      1. Let _value_ be the VLQUnsignedValue of |VlqDigitList|.
+      1. If _value_ is ≥ 2<sup>32</sup>, throw an error.
+      1. Return _value_.
+    </emu-alg>
+    <emu-grammar>
       VlqDigitList ::
-        TerminalDigit
         ContinuationDigit VlqDigitList
-
+    </emu-grammar>
+    <emu-alg>
+      1. Let _left_ be the VLQUnsignedValue of |ContinuationDigit|.
+      1. Let _right_ be the VLQUnsignedValue of |VlqDigitList|.
+      1. Return _left_ + _right_ × 2<sup>5</sup>.
+    </emu-alg>
+    <emu-grammar>
       TerminalDigit ::
         `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R`
         `S` `T` `U` `V` `W` `X` `Y` `Z` `a` `b` `c` `d` `e` `f`
-
+    </emu-grammar>
+    <emu-alg>
+      1. Let _digit_ be the character matched by this production.
+      1. Let _value_ be the integer corresponding to _digit_, according to the <emu-xref href="#sec-references-informative">base64</emu-xref> encoding as defined by IETF RFC 4648.
+      1. Assert: _value_ &lt; 32.
+      1. Return _value_.
+    </emu-alg>
+    <emu-grammar>
       ContinuationDigit ::
         `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x`
         `y` `z` `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `+` `/`
     </emu-grammar>
-
-    <emu-clause id="sec-VLQSignedValue" type="sdo">
-      <h1>VLQSignedValue ( ): an integer</h1>
-      <dl class="header"></dl>
-      <emu-grammar>
-        Vlq :: VlqDigitList
-      </emu-grammar>
-      <emu-alg>
-        1. Let _unsigned_ be the VLQUnsignedValue of |VlqDigitList|.
-        1. If _unsigned_ modulo 2 = 1, let _sign_ be -1.
-        1. Else, let _sign_ be 1.
-        1. Let _value_ be floor(_unsigned_ / 2).
-        1. If _value_ is 0 and _sign_ is -1, return -2<sup>31</sup>.
-        1. If _value_ is ≥ 2<sup>31</sup>, throw an error.
-          <emu-note>
-            The check is required here as _unsigned_ is the VLQUnsignedValue of |VlqDigitList|, not of |Vlq|.
-          </emu-note>
-        1. Return _sign_ × _value_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-VLQUnsignedValue" type="sdo">
-      <h1>VLQUnsignedValue ( ): an non-negative integer</h1>
-      <dl class="header"></dl>
-      <emu-grammar>
-        Vlq :: VlqDigitList
-      </emu-grammar>
-      <emu-alg>
-        1. Let _value_ be the VLQUnsignedValue of |VlqDigitList|.
-        1. If _value_ is ≥ 2<sup>32</sup>, throw an error.
-        1. Return _value_.
-      </emu-alg>
-      <emu-grammar>
-        VlqDigitList ::
-          ContinuationDigit VlqDigitList
-      </emu-grammar>
-      <emu-alg>
-        1. Let _left_ be the VLQUnsignedValue of |ContinuationDigit|.
-        1. Let _right_ be the VLQUnsignedValue of |VlqDigitList|.
-        1. Return _left_ + _right_ × 2<sup>5</sup>.
-      </emu-alg>
-      <emu-grammar>
-        TerminalDigit ::
-          `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R`
-          `S` `T` `U` `V` `W` `X` `Y` `Z` `a` `b` `c` `d` `e` `f`
-      </emu-grammar>
-      <emu-alg>
-        1. Let _digit_ be the character matched by this production.
-        1. Let _value_ be the integer corresponding to _digit_, according to the <emu-xref href="#sec-references-informative">base64</emu-xref> encoding as defined by IETF RFC 4648.
-        1. Assert: _value_ &lt; 32.
-        1. Return _value_.
-      </emu-alg>
-      <emu-grammar>
-        ContinuationDigit ::
-          `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x`
-          `y` `z` `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `+` `/`
-      </emu-grammar>
-      <emu-alg>
-        1. Let _digit_ be the character matched by this production.
-        1. Let _value_ be the integer corresponding to _digit_, according to the <emu-xref href="#sec-references-informative">base64</emu-xref> encoding as defined by IETF RFC 4648.
-        1. Assert: 32 ≤ _value_ &lt; 64.
-        1. Return _value_ - 32.
-      </emu-alg>
-    </emu-clause>
+    <emu-alg>
+      1. Let _digit_ be the character matched by this production.
+      1. Let _value_ be the integer corresponding to _digit_, according to the <emu-xref href="#sec-references-informative">base64</emu-xref> encoding as defined by IETF RFC 4648.
+      1. Assert: 32 ≤ _value_ &lt; 64.
+      1. Return _value_ - 32.
+    </emu-alg>
   </emu-clause>
 </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -108,7 +108,7 @@
   <p>The source map format does not have version numbers anymore, and it is instead hard-coded to always be "3".</p>
   <p>In 2023-2024, the source map format was developed into a more precise Ecma standard, with significant contributions from many people. Further iteration on the source map format is expected to come from TC39-TG4.</p>
   <p>
-    Asumu Takikawa, Nicolò Ribaudo, Jon Kuperman<br/>
+    Asumu Takikawa, Nicolò Ribaudo, Jon Kuperman<br>
     ECMA-426, 1<sup>st</sup> edition, Project Editors
   </p>
 </emu-intro>
@@ -188,6 +188,7 @@
       <p>All abstract operations declared in this specification are implicitly assumed to either return a normal completion containing the algorithm's declared return type, or a throw completion. For example, an abstract operation declared as</p>
 
       <blockquote>
+
         <emu-clause id="example-get-the-answer" type="abstract operation" example>
           <h1>
             GetTheAnswer (
@@ -199,6 +200,7 @@
       </blockquote>
       <p>is equivalent to:</p>
       <blockquote>
+
         <emu-clause id="example-get-the-answer-2" type="abstract operation" example>
           <h1>
             GetTheAnswer2 (
@@ -219,7 +221,6 @@
         1. Let _result_ be ReturnIfAbrupt(GetTheAnswer(_value_)).
         1. Let _second_ be Completion(GetTheAnswer(_value_)).
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sec-optional-errors">
@@ -275,12 +276,99 @@
       <emu-note>That means that "A" (`LATIN CAPITAL LETTER A`) measures as 1 code unit, and "🔥" (`FIRE`) measures as 2 code units. Source maps for other content types may diverge from this.</emu-note>
     </dd>
   </dl>
+
+  <emu-clause id="sec-vlq-grammar">
+    <h1>base64 VLQ grammar</h1>
+    <p>A base64-encoded variable-length quantity adheres to the following lexical grammar:</p>
+
+    <emu-grammar type="definition">
+      Vlq ::
+        VlqDigitList
+
+      VlqDigitList ::
+        DigitWithoutContinuationBit
+        DigitWithContinuationBit VlqDigitList
+
+      DigitWithoutContinuationBit :: one of
+        `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R`
+        `S` `T` `U` `V` `W` `X` `Y` `Z` `a` `b` `c` `d` `e` `f`
+
+      DigitWithContinuationBit :: one of
+        `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x`
+        `y` `z` `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `+` `/`
+    </emu-grammar>
+
+    <emu-clause id="sec-DecodeSignedBase64VLQ" type="abstract operation">
+      <h1>
+        DecodeSignedBase64VLQ (
+          _vlq_: a |Vlq| Parse Node,
+        ): an integer
+      </h1>
+      <dl class="header"></dl>
+      <emu-alg>
+        1. Let _accumulator_ be a new record { [[Value]]: 0, [[Shift]]: 0 }.
+        1. Perform DecodeBase64VLQ of _vlq_ with arguments _accumulator_.
+        1. If _accumulator_.[[Value]] modulo 2 = 1, let _sign_ be -1.
+        1. Else, let _sign_ be 1.
+        1. Let _result_ to _accumulator_.[[Value]] / 2.
+        1. Return _result_ * _sign_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-DecodeBase64VLQ" type="sdo">
+      <h1>
+        DecodeBase64VLQ (
+          _accumulator_: a Record with an integer [[Value]] field and a non-negative integer [[Shift]] field,
+        )
+      </h1>
+      <dl class="header"></dl>
+      <emu-grammar>
+        VlqDigitList ::
+          DigitWithoutContinuationBit
+      </emu-grammar>
+      <emu-alg>
+        1. Let _byte_ be DecodeBase64Digit(|DigitWithoutContinuationBit|).
+        1. Assert: _byte_ &lt; 32.
+        1. Set _accumulator_.[[Value]] to _accumulator_.[[Value]] + _byte_ × 2<sup>_accumulator_.[[Shift]]</sup>.
+        1. If _accumulator_.[[Value]] ≥ 2<sup>31</sup>, throw an error.
+        1. Set _accumulator_.[[Shift]] to _accumulator_.[[Shift]] × 2<sup>5</sup>.
+      </emu-alg>
+      <emu-grammar>
+        VlqDigitList ::
+          DigitWithContinuationBit VlqDigitList
+      </emu-grammar>
+      <emu-alg>
+        1. Let _byte_ be DecodeBase64Digit(|DigitWithContinuationBit|).
+        1. Assert: _byte_ ≥ 32 and _byte_ &lt; 64.
+        1. Set _byte_ to floor(_byte_ / 32).
+        1. Set _accumulator_.[[Value]] to _accumulator_.[[Value]] + _byte_ × 2<sup>_accumulator_.[[Shift]]</sup>.
+        1. If _accumulator_.[[Value]] ≥ 2<sup>31</sup>, throw an error.
+        1. Set _accumulator_.[[Shift]] to _accumulator_.[[Shift]] × 2<sup>5</sup>.
+        1. Perform DecodeBase64VLQ of |VlqDigitList| with argument _accumulator_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-DecodeBase64Digit" type="abstract operation">
+      <h1>
+        DecodeBase64Digit (
+          _digit_: a |DigitWithoutContinuationBit| or a |DigitWithContinuationBit| Parse Node,
+        ): an integer
+      </h1>
+      <dl class="header"></dl>
+      <emu-alg>
+        1. Assert: The source text matched by _digit_ is a valid <emu-xref href="#sec-references-informative">base64</emu-xref> character as defined by IETF RFC 4648.
+        1. Let _value_ be the integer corresponding to the source text matched by _digit_, according to the <emu-xref href="#sec-references-informative">base64</emu-xref> encoding as defined by IETF RFC 4648.
+        1. Assert: _value_ &lt; 2<sup>6</sup>.
+        1. Return _value_.
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
 </emu-clause>
 
 <emu-clause id="sec-json-values-utilities">
   <h1>JSON values utilities</h1>
 
-  <p>While this specification's algorithms are defined on top of ECMA-262 internals, it is meant to be easily implementable by non-JavaScript platforms. This section contains utilities for working with JSON values, abstracting away ECMA-262  details from the rest of the document.</p>
+  <p>While this specification's algorithms are defined on top of ECMA-262 internals, it is meant to be easily implementable by non-JavaScript platforms. This section contains utilities for working with JSON values, abstracting away ECMA-262 details from the rest of the document.</p>
 
   <p>A <dfn id="type-json-value" variants="JSON values">JSON value</dfn> is either a JSON object, a JSON array, a <emu-xref href="#sec-ecmascript-language-types-string-type">String</emu-xref>, a <emu-xref href="#sec-ecmascript-language-types-number-type">Number</emu-xref>, a <emu-xref href="#sec-ecmascript-language-types-boolean-type">Boolean</emu-xref>, or <emu-xref href="#sec-ecmascript-language-types-null-type">*null*</emu-xref>.</p>
 
@@ -361,7 +449,7 @@
     <h1>
       StringSplit (
         _string_: a String,
-        _separators_: a List of String
+        _separators_: a List of String,
       ): a List of Strings
     </h1>
     <dl class="header">
@@ -521,7 +609,7 @@
 
       <emu-clause id="sec-GetOptionalString" type="abstract operation">
         <h1>
-          GetOptionalString(
+          GetOptionalString (
             _object_: a JSON object,
             _key_: a String,
           ): a String or *null*
@@ -537,7 +625,7 @@
 
       <emu-clause id="sec-GetOptionalListOfStrings" type="abstract operation">
         <h1>
-          GetOptionalListOfStrings(
+          GetOptionalListOfStrings (
             _object_: a JSON object,
             _key_: a String,
           ): a List of Strings
@@ -561,7 +649,7 @@
 
       <emu-clause id="sec-GetOptionalListOfOptionalStrings" type="abstract operation">
         <h1>
-          GetOptionalListOfOptionalStrings(
+          GetOptionalListOfOptionalStrings (
             _object_: a JSON object,
             _key_: a String,
           ): a List of either Strings or *null*
@@ -577,7 +665,7 @@
           1. For each element _item_ of JSONArrayIterate(_values_),
             1. If _item_ is a String, append _item_ to _list_.
             1. Else,
-              1. If _item_ &ne; *null*, optionally report an error.
+              1. If _item_ ≠ *null*, optionally report an error.
               1. Append *null* to _list_.
           1. Return _list_.
         </emu-alg>
@@ -585,7 +673,7 @@
 
       <emu-clause id="sec-GetOptionalListOfArrayIndexes" type="abstract operation">
         <h1>
-          GetOptionalListOfArrayIndexes(
+          GetOptionalListOfArrayIndexes (
             _object_: an Object,
             _key_: a String,
           ): a List of non-negative integers
@@ -599,11 +687,11 @@
             1. Optionally report an error.
             1. Return _list_.
           1. For each element _item_ of JSONArrayIterate(_values_),
-            1. If _item_ is an integral Number, _item_ &ne; *0*<sub>𝔽</sub>, and _item_ &ge; *0*<sub>𝔽</sub>, then
+            1. If _item_ is an integral Number, _item_ ≠ *0*<sub>𝔽</sub>, and _item_ ≥ *0*<sub>𝔽</sub>, then
               1. Append ℝ(_item_) to _list_.
             1. Else,
-              1. If _item_ &ne; *null*, optionally report an error.
-              <!-- TODO: Should this step be removed, so that the list only contains numbers? -->
+              1. If _item_ ≠ *null*, optionally report an error.
+                <!-- TODO: Should this step be removed, so that the list only contains numbers? -->
               1. Append *null* to _list_.
           1. Return _list_.
         </emu-alg>
@@ -675,134 +763,217 @@
       </table>
     </emu-table>
 
+    <emu-clause id="sec-mappings-grammar">
+      <h1>Mappings grammar</h1>
+      <p>The mappings String must adhere to the following grammar:</p>
+
+      <emu-grammar type="definition">
+        Mappings :
+          SemicolonList? Segment SemicolonList?
+
+        Segment :
+          MappingList
+          MappingList SemicolonList Segment
+
+        MappingList :
+          Mapping
+          MappingList `,` Mapping
+
+        SemicolonList :
+          `;`
+          SemicolonList `;`
+
+        Mapping :
+          GeneratedColumn
+          GeneratedColumn OriginalSource OriginalLine OriginalColumn Name?
+
+        GeneratedColumn :
+          Vlq
+
+        OriginalSource :
+          Vlq
+
+        OriginalLine :
+          Vlq
+
+        OriginalColumn :
+          Vlq
+
+        Name :
+          Vlq
+      </emu-grammar>
+
+      <p>A <dfn id="decode-mapping-state-record" variants="Decode Mapping State Records">Decoded Mapping State Record</dfn> has the following fields:</p>
+      <emu-table id="table-decode-mapping-state-fields" caption="Fields of Decode Mapping State Records">
+        <table>
+          <thead>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[GeneratedLine]]</td>
+            <td>a non-negative integer</td>
+          </tr>
+          <tr>
+            <td>[[GeneratedColumn]]</td>
+            <td>a non-negative integer</td>
+          </tr>
+          <tr>
+            <td>[[SourceIndex]]</td>
+            <td>a non-negative integer</td>
+          </tr>
+          <tr>
+            <td>[[OriginalLine]]</td>
+            <td>a non-negative integer</td>
+          </tr>
+          <tr>
+            <td>[[OriginalColumn]]</td>
+            <td>a non-negative integer</td>
+          </tr>
+          <tr>
+            <td>[[NameIndex]]</td>
+            <td>a non-negative integer</td>
+          </tr>
+        </table>
+      </emu-table>
+
+      <emu-clause id="sec-DecodeMappingsSdo" type="sdo">
+        <h1>
+          DecodeMappingsSdo (
+            _state_: a Decode Mapping State Record,
+            _mappings_: a List of Decoded Mapping Records,
+            _names_: a List of Strings,
+            _sources_: a List of Decoded Source Records,
+          )
+        </h1>
+        <dl class="header"></dl>
+        <emu-grammar>
+          Mappings :
+            SemicolonList? Segment SemicolonList?
+
+          Segment :
+            MappingList
+            MappingList SemicolonList Segment
+
+          MappingList :
+            Mapping
+            MappingList `,` Mapping
+        </emu-grammar>
+        <emu-alg>
+          1. For each child node _child_ of this Parse Node, do
+            1. If _child_ is an instance of a nonterminal, then
+              1. Perform DecodeMappingsSdo of _child_ with arguments _state_, _mappings_, _names_ and _sources_.
+        </emu-alg>
+        <emu-grammar>
+          Mapping :
+            GeneratedColumn
+        </emu-grammar>
+        <emu-alg>
+          1. Perform DecodeMappingsSdo of |GeneratedColumn| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Let _decodedMapping_ be a new DecodedMappingRecord { [[GeneratedLine]]: _state_.[[GeneratedLine]], [[GeneratedColumn]]: _state_.[[GeneratedColumn]], [[OriginalSource]]: *null*, [[OriginalLine]]: *null*, [[OriginalColumn]]: *null*, [[Name]]: *null* }.
+          1. Append _decodedMapping_ to _mappings_.
+        </emu-alg>
+        <emu-grammar>
+          Mapping :
+            GeneratedColumn OriginalSource OriginalLine OriginalColumn Name?
+        </emu-grammar>
+        <emu-alg>
+          1. Perform DecodeMappingsSdo of |GeneratedColumn| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsSdo of |OriginalSource| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsSdo of |OriginalLine| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Perform DecodeMappingsSdo of |OriginalColumn| with arguments _state_, _mappings_, _names_ and _sources_.
+          1. Let _source_ be _sources_.[_state_.[[SourceIndex]]].
+          1. If |Name| is present, then
+            1. Perform DecodeMappingsSdo of |Name| with arguments _state_, _mappings_, _names_ and _sources_.
+            1. Let _name_ be _names_.[_state_.[[NameIndex]]].
+          1. Else, let _name_ be *null*.
+          1. Let _decodedMapping_ be a new DecodedMappingRecord { [[GeneratedLine]]: _state_.[[GeneratedLine]], [[GeneratedColumn]]: _state_.[[GeneratedColumn]], [[OriginalSource]]: _source_, [[OriginalLine]]: _state_.[[OriginalLine]], [[OriginalColumn]]: _state_.[[OriginalColumn]], [[Name]]: _name_ }.
+          1. Append _decodedMapping_ to _mappings_.
+        </emu-alg>
+        <emu-grammar>
+          SemicolonList :
+            `;`
+            SemicolonList `;`
+        </emu-grammar>
+        <emu-alg>
+          1. Set _state_.[[GeneratedLine]] to _state_.[[GeneratedLine]] + 1.
+          1. Set _state_.[[GeneratedColumn]] to 0.
+          1. If |SemicolonList| is present, then
+            1. Perform DecodeMappingsSdo on |SemicolonList| with arguments _state_, _mappings_, _names_ and _sources_.
+        </emu-alg>
+        <emu-grammar>
+          GeneratedColumn :
+            Vlq
+        </emu-grammar>
+        <emu-alg>
+          1. Let _relativeColumn_ be DecodeBase64VLQ(|Vlq|).
+          1. Set _state_.[[GeneratedColumn]] to _state_.[[GeneratedColumn]] + _relativeColumn_.
+          1. If _state_.[[GeneratedColumn]] &lt; 0, optionally report an error.
+        </emu-alg>
+        <emu-grammar>
+          OriginalSource :
+            Vlq
+        </emu-grammar>
+        <emu-alg>
+          1. Let _relativeSourceIndex_ be DecodeBase64VLQ(|Vlq|).
+          1. Set _state_.[[SourceIndex]] to _state_.[[SourceIndex]] + _relativeSourceIndex_.
+          1. If _state_.[[SourceIndex]] &lt; 0 or _state.[[SourceIndex]] ≥ the number of elements of _sources_, optionally report an error.
+        </emu-alg>
+        <emu-grammar>
+          OriginalLine :
+            Vlq
+        </emu-grammar>
+        <emu-alg>
+          1. Let _relativeLine_ be DecodeBase64VLQ(|Vlq|).
+          1. Set _state_.[[OriginalLine]] to _state_.[[OriginalLine]] + _relativeLine_.
+          1. If _state_.[[OriginalLine]] &lt; 0, optionally report an error.
+        </emu-alg>
+        <emu-grammar>
+          OriginalColumn :
+            Vlq
+        </emu-grammar>
+        <emu-alg>
+          1. Let _relativeColumn_ be DecodeBase64VLQ(|Vlq|).
+          1. Set _state_.[[OriginalColumn]] to _state_.[[OriginalColumn]] + _relativeColumn_.
+          1. If _state_.[[OriginalColumn]] &lt; 0, optionally report an error.
+        </emu-alg>
+        <emu-grammar>
+          Name :
+            Vlq
+        </emu-grammar>
+        <emu-alg>
+          1. Let _relativeName_ be DecodeBase64VLQ(|Vlq|).
+          1. Set _state_.[[NameIndex]] to _state_.[[NameIndex]] + _relativeName_.
+          1. If _state_.[[NameIndex]] &lt; 0 or _state_[[NameIndex]] ≥ the number of elements of _sources_, optionally report an error.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
     <emu-clause id="sec-DecodeMappings" type="abstract operation">
       <h1>
         DecodeMappings (
-          _mappings_: a String,
+          _rawMappings_: a String,
           _names_: a List of Strings,
           _sources_: a List of Decoded Source Records,
         ): a List of Decoded Mapping Record
       </h1>
       <dl class="header"></dl>
       <emu-alg>
-        1. Perform ValidateBase64VLQGroupings(_mappings_).
-        1. Let _decodedMappings_ be a new empty List.
-        1. Let _groups_ be StringSplit(_mappings_, « *";"* »).
-        1. Let _generatedLine_ be 0.
-        1. Let _originalLine_ be 0.
-        1. Let _originalColumn_ be 0.
-        1. Let _sourceIndex_ be 0.
-        1. Let _nameIndex_ be 0.
-        1. Repeat, while _generatedLine_ is less than the number of elements of _groups_,
-          1. If _groups_[_generatedLine_] &ne; *""*, then
-            1. Let _segments_ be StringSplit(_groups_[_generatedLine_], « *","* »).
-            1. Let _generatedColumn_ be 0.
-            1. For each _segment_ of _segments_, do
-              1. Let _position_ be the Record { [[Value]]: 0 }.
-              1. Let _relativeGeneratedColumn_ be DecodeBase64VLQ(_segment_, _position_).
-              1. If _relativeGeneratedColumn_ = *null*, optionally report an error.
-              1. Else,
-                1. Set _generatedColumn_ to _generatedColumn_ + _relativeGeneratedColumn_.
-                1. If _generatedColumn_ &lt; 0, optionally report an error.
-                1. Else,
-                  1. Let _decodedMapping_ be the Decoded Mapping Record { [[GeneratedLine]]: _generatedLine_, [[GeneratedColumn]]: _generatedColumn_, [[OriginalSource]]: *null*, [[OriginalLine]]: *null*, [[OriginalColumn]]: *null*, [[Name]]: *null* }.
-                  1. Append _decodedMapping_ to _decodedMappings_.
-                  1. Let _relativeSourceIndex_ be DecodeBase64VLQ(_segment_, _position_).
-                  1. Let _relativeOriginalLine_ be DecodeBase64VLQ(_segment_, _position_).
-                  1. Let _relativeOriginalColumn_ be DecodeBase64VLQ(_segment_, _position_).
-                  1. If _relativeOriginalColumn_ = *null* and _relativeSourceIndex_ &ne; *null*, optionally report an error.
-                  1. Else if _relativeOriginalColumn_ &ne; *null*,
-                    1. Set _sourceIndex_ to _sourceIndex_ + _relativeSourceIndex_.
-                    1. Set _originalLine_ to _originalLine_ + _relativeOriginalLine_.
-                    1. Set _originalColumn_ to _originalColumn_ + _relativeOriginalColumn_.
-                    1. If _sourceIndex_ &lt; 0, _originalLine_ &lt; 0, _originalColumn_ &lt; 0, or _sourceIndex_ &ge; the number of elements of _source_, then
-                      1. Optionally report an error.
-                    1. Else,
-                      1. Set _decodedMapping_.[[OriginalSource]] to _sources_[_sourceIndex_].
-                      1. Set _decodedMapping_.[[OriginalLine]] to _originalLine_.
-                      1. Set _decodedMapping_.[[OriginalColumn]] to _originalColumn_.
-                    1. Let _relativeNameIndex_ be DecodeBase64VLQ(_segment_, _position_).
-                    1. If _relativeNameIndex_ &ne; *null*, then
-                      1. Set _nameIndex_ to _nameIndex_ + _relativeNameIndex_.
-                      1. If _nameIndex_ &lt; 0 or _nameIndex_ &ge; the number of elements of _names_, then
-                        1. Optionally report an error.
-                      1. Else,
-                        1. Set _decodedMapping_.[[Name]] to _names_[_nameIndex_].
-                    1. If _position_.[[Value]] &ne; length of _segment_, optionally report an error.
-          1. Set _generatedLine_ to _generatedLine_ + 1.
-        1. Return _decodedMappings_.
+        1. Let _mappings_ be a new empty List.
+        1. Let _mappingsNode_ be the root Parse Node when parsing _rawMappings_ using |Mappings| as the goal symbol.
+        1. If parsing failed, then
+          1. Optionally report an error.
+          1. Return _mappings_.
+        1. Let _state_ be a new Decode Mapping State Record with all fields set to 0.
+        1. Perform DecodeMappingsSdo of _mappingsNode_ with arguments _state_, _mappings_, _names_ and _sources_.
+        1. Return _mappings_.
       </emu-alg>
-
-      <emu-clause id="sec-ValidateBase64VLQGroupings" type="abstract operation">
-        <h1>
-          ValidateBase64VLQGroupings (
-            _groupings_: a String,
-          ): ~unused~
-        </h1>
-        <dl class="header"></dl>
-        <emu-alg>
-          1. If _groupings_ contains any code unit other than:
-              <ul>
-                <li>U+002B (`+`), U+002C (`,`), U+002F (`/`), or U+003B (`;`);</li>
-                <li>U+0030 (`0`) to U+0039 (`9`);</li>
-                <li>U+0041 (`A`) to U+005A (`Z`);</li>
-                <li>U+0061 (`a`) to U+007A (`z`)</li>
-              </ul>
-              throw an error.
-          1. Return ~unused~.
-        </emu-alg>
-
-        <emu-note>These are the valid <emu-xref href="#sec-references-informative">base64</emu-xref> characters (excluding the padding character `=`), together with `,` and `;`.</emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-DecodeBase64VLQ" type="abstract operation">
-        <h1>
-          DecodeBase64VLQ (
-            _segment_: a String,
-            _position_: a Record with a non-negative integer [[Value]] field,
-          ): an integer or *null*
-        </h1>
-        <dl class="header"></dl>
-        <emu-alg>
-          1. Let _segmentLen_ be the length of _segment_.
-          1. If _position_.[[Value]] = _segmentLen_, return *null*.
-          1. Let _first_ be ConsumeBase64ValueAt(_segment_, _position_).
-          1. Assert: _first_ &lt; 64.
-          1. If _first_ modulo 2 is 0, let _sign_ be 1.
-          1. Else, let _sign_ be -1.
-          1. Let _value_ be min(floor(_first_ / 2), 2<sup>4</sup> - 1).
-          1. Let _nextShift_ be 16.
-          1. Let _currentByte_ be _first_.
-          1. Repeat, while floor(_currentByte_ / 2<sup>5</sup>) modulo 2 = 1,
-            1. If _position_.[[Value]] = _segmentLen_, throw an error.
-            1. Set _currentByte_ to ConsumeBase64ValueAt(_segment_, _position_).
-            1. Let _chunk_ be min(_currentByte_, 2<sup>5</sup> - 1).
-            1. Set _value_ to _value_ + _chunk_ × _nextShift_.
-            1. If _value_ &ge; 2<sup>31</sup>, throw an error.
-            1. Set _nextShift_ to _nextShift_ × 2<sup>5</sup>.
-          1. If _value_ is 0 and _sign_ is -1, return -2<sup>31</sup>.
-          1. Return _sign_ × _value_.
-        </emu-alg>
-
-        <emu-clause id="ConsumeBase64ValueAt" type="abstract operation">
-          <h1>
-            ConsumeBase64ValueAt (
-              _string_: a String,
-              _position_: a Record with a non-negative integer [[Value]] field,
-            ): a non-negative integer
-          </h1>
-          <dl class="header"></dl>
-          <emu-alg>
-            1. Assert: _position_.[[Value]] is a non-negative integer smaller than the length of _string_.
-            1. Let _char_ be the substring of _string_ from _position_ to _position_ + 1.
-            1. Assert: _char_ is a valid <emu-xref href="#sec-references-informative">base64</emu-xref> character as defined by IETF RFC 4648.
-            1. Set _position_.[[Value]] to _position_.[[Value]] + 1.
-            1. Return the integer corresponding to _char_, according to the <emu-xref href="#sec-references-informative">base64</emu-xref> encoding as defined by IETF RFC 4648.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-note>In addition to returning the decoded value, these algorithms update the _position_ passed in by the caller.</emu-note>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-mappings-for-generated-javascript-code">
@@ -839,12 +1010,15 @@
 
       <ul>
         <li>
-          <p>The |BindingIdentifier|(s) for |LexicalDeclaration|, |VariableStatement| and |ParameterList|.</p></li>
+          <p>The |BindingIdentifier|(s) for |LexicalDeclaration|, |VariableStatement| and |ParameterList|.</p>
+        </li>
         <li>
           <p>The |BindingIdentifier| for |FunctionDeclaration|, |FunctionExpression|, |AsyncFunctionDeclaration|, |AsyncFunctionExpression|, |GeneratorDeclaration|, |GeneratorExpression|, |AsyncGeneratorDeclaration|, and |AsyncGeneratorExpression| if it exists, or the opening parenthesis `(` preceding the |FormalParameters| otherwise.</p>
 
-          <p>Source map generators may chose to emit a named mapping on the opening parenthesis regardless of
-          the presence of the |BindingIdentifier|.</p>
+          <p>
+            Source map generators may chose to emit a named mapping on the opening parenthesis regardless of
+            the presence of the |BindingIdentifier|.
+          </p>
         </li>
         <li>
           <p>For an |ArrowFunction| or |AsyncArrowFunction|:</p>
@@ -890,20 +1064,20 @@
         1. Let _decodedSources_ be a new empty List.
         1. Let _sourcesContentCount_ be the the number of elements in _sourcesContent_.
         1. Let _sourceUrlPrefix_ be *""*.
-        1. If _sourceRoot_ &ne; *null*, then
+        1. If _sourceRoot_ ≠ *null*, then
           1. If _sourceRoot_ contains the code point U+002F (SOLIDUS), then
             1. Let _idx_ be the index of the last occurrence of U+002F (SOLIDUS) in _sourceRoot_.
             1. Set _sourceUrlPrefix_ to the substring of _sourceRoot_ from 0 to _idx_ + 1.
           1. Else, set _sourceUrlPrefix_ to the string-concatenation of _sourceRoot_ and *"/"*.
         1. For each _source_ in _sources_ with index _index_, do
           1. Let _decodedSource_ be the Decoded Source Record { [[URL]]: *null*, [[Content]]: *null*, [[Ignored]]: *false* }.
-          1. If _source_ &ne; *null*, then
+          1. If _source_ ≠ *null*, then
             1. Set _source_ to the string-concatenation of _sourceUrlPrefix_ and _source_.
             1. Let _sourceURL_ be the result of URL parsing _source_ with _baseURL_.
             1. If _sourceURL_ is ~failure~, optionally report an error.
             1. Else, set _decodedSource_.[[URL]] to _sourceURL_.
           1. If _ignoredSources_ contains _index_, set _decodedSource_.[[Ignored]] to *true*.
-          1. If _sourcesContentCount_ &ge; _index_, set _decodedSource_.[[Content]] to _sourcesContent_[_index_].
+          1. If _sourcesContentCount_ ≥ _index_, set _decodedSource_.[[Content]] to _sourcesContent_[_index_].
           1. Append _decodedSource_ to _decodedSources_.
         1. Return _decodedSources_.
       </emu-alg>
@@ -977,7 +1151,7 @@
       1. If _sectionsField_ is not a JSON array, throw an error.
       1. If JSONObjectGet(_json_, *"version"*) is not *3<sub>𝔽</sub>*, optionally report an error.
       1. Let _fileField_ be GetOptionalString(_json_, *"file"*).
-      1. Let _sourceMap_ be the Decoded Source Map Record { [[File]]: _fileField_, [[Sources]]:  « », [[Mappings]]: « » }.
+      1. Let _sourceMap_ be the Decoded Source Map Record { [[File]]: _fileField_, [[Sources]]: « », [[Mappings]]: « » }.
       1. Let _previousOffset_ be *null*.
       1. Let _previousLastMapping_ be *null*.
       1. For each _section_ of JSONArrayIterate(_sectionsField_), do
@@ -993,7 +1167,7 @@
           1. If _offsetColumn_ is not an integral Number, then
             1. Optionally report an error.
             1. Set _offsetColumn_ to *0*<sub>𝔽</sub>.
-          1. If _previousOffset_ &ne; *null*, then
+          1. If _previousOffset_ ≠ *null*, then
             1. If _offsetLine_ &lt; JSONObjectGet(_previousOffset_, *"line"*), optionally report an error.
             1. Else if _offsetLine_ = JSONObjectGet(_previousOffset_, *"line"*) and _offsetColumn_ &lt; Get(_previousOffset_, *"column"*), optionally report an error.
           1. If _previousLastMapping_ is not *null*, then
@@ -1090,7 +1264,7 @@
       <emu-note example>
         <p>The following JavaScript code links to a source map, but it does not do so <emu-xref href="#umambiguous-linking">unambiguously</emu-xref>:</p>
 
-<pre><code class="javascript">let a = &#x60;
+        <pre><code class="javascript">let a = &#x60;
 &#x2F;&#x2F;# sourceMappingURL=foo.js.map
 &#x2F;&#x2F;&#x60;</code></pre>
 
@@ -1100,7 +1274,7 @@
       <emu-note issue>
         <p>Having multiple ways to extract a source map URL, that can lead to different results, can have negative security and privacy implications. Implementations that need to detect which source maps are potentially going to be loaded are strongly encouraged to always apply both algorithms, rather than just assuming that they will give the same result.</p>
 
-        <p>A fix to this problem is being worked on, and is expected to be included in a future version of the standard. It will likely involve early returning from the below algorithms whenever there is a comment (or comment-like) that contains the characters U+0060 (&#x60;), U+0022 ("), or U+0027 ('), or the the sequence U+002A U+002F (*/).</p>
+        <p>A fix to this problem is being worked on, and is expected to be included in a future version of the standard. It will likely involve early returning from the below algorithms whenever there is a comment (or comment-like) that contains the characters U+0060 (`), U+0022 ("), or U+0027 ('), or the the sequence U+002A U+002F (*/).</p>
       </emu-note>
 
       <emu-clause id="sec-JavaScriptExtractSourceMapURL" type="abstract operation">
@@ -1120,7 +1294,7 @@
           1. Let _tokens_ be the List of tokens obtained by parsing _source_ according to <emu-xref href="#sec-ecmascript-language-lexical-grammar">ECMA-262's lexical grammar</emu-xref>.
           1. For each _token_ in _tokens_, in reverse order, do:
             1. If _token_ is not |SingleLineComment| or |MultiLineComment|, return *null*.
-            <!-- TODO: We need to define a SDO for this, to make explicit what the contents actually are -->
+              <!-- TODO: We need to define a SDO for this, to make explicit what the contents actually are -->
             1. Let _comment_ be the content of _token_.
             1. Let _sourceMapURL_ be MatchSourceMapURL(_comment_).
             1. If _sourceMapURL_ is a String, return _sourceMapURL_.
@@ -1282,7 +1456,7 @@ return lastURL;</code></pre>
             1. Perform Call(_promiseCapability_.[[Reject]], *undefined*, « a new *TypeError* »).
             1. Return.
           1. If _url_'s scheme is an HTTP(S) scheme and the byte sequence \``)]}'`\` is a byte-sequence-prefix of _bodyBytes_, then
-            1. While _bodyBytes_'s _length_ &ne; 0 and _bodyBytes_[0] is not an HTTP newline byte, remove the 0th element from _bodyBytes_.
+            1. While _bodyBytes_'s _length_ ≠ 0 and _bodyBytes_[0] is not an HTTP newline byte, remove the 0th element from _bodyBytes_.
           1. Let _bodyString_ be Completion(UTF-8 decode of _bodyBytes_).
           1. IfAbruptRejectPromise(_bodyString_, _promiseCapability_).
           1. Let _jsonValue_ be Completion(ParseJSON(_bodyString_)).
@@ -1339,7 +1513,7 @@ return lastURL;</code></pre>
   <emu-annex id="sec-multi-level-mapping">
     <h1>Multi-level mapping</h1>
 
-    <p>It is getting more common to have tools generate sources from some DSL (templates) or compile TypeScript &rightarrow; JavaScript &rightarrow; minified JavaScript, resulting in multiple translations before the final source map is created. This problem can be handled in one of two ways. The easy but lossy way is to ignore the intermediate steps in the process for the purposes of debugging, the source location information from the translation is either ignored (the intermediate translation is considered the “Original Source”) or the source location information is carried through (the intermediate translation hidden). The more complete way is to support multiple levels of mapping: if the Original Source also has a source map reference, the user is given the choice of using that as well.</p>
+    <p>It is getting more common to have tools generate sources from some DSL (templates) or compile TypeScript → JavaScript → minified JavaScript, resulting in multiple translations before the final source map is created. This problem can be handled in one of two ways. The easy but lossy way is to ignore the intermediate steps in the process for the purposes of debugging, the source location information from the translation is either ignored (the intermediate translation is considered the “Original Source”) or the source location information is carried through (the intermediate translation hidden). The more complete way is to support multiple levels of mapping: if the Original Source also has a source map reference, the user is given the choice of using that as well.</p>
 
     <p>However, it is unclear what a "source map reference" looks like in anything other than JavaScript. More specifically, what a source map reference looks like in a language that doesn't support JavaScript-style single-line comments.</p>
   </emu-annex>
@@ -1353,18 +1527,18 @@ return lastURL;</code></pre>
   <!-- All specifications references here should be also listed in the "References" section at the beginning of the document -->
 
   <dl>
-    <dt>WebAssembly Core Specification &lt;<a href="https://www.w3.org/TR/wasm-core-2/">https://www.w3.org/TR/wasm-core-2/</a>&gt;</dt>
+    <dt>WebAssembly Core Specification &lt;<a href="https://www.w3.org/TR/wasm-core-2/">https://www.w3.org/TR/wasm-core-2/</a>></dt>
     <dd>
       <dfn id="external-webassembly-custom-section" variants="custom sections"><a href="https://www.w3.org/TR/wasm-core-2/#custom-section%E2%91%A0">custom section</a></dfn>,
       <dfn id="external-webassembly-module_decode"><a href="https://www.w3.org/TR/wasm-core-2/#modules%E2%91%A0%E2%91%A4">module_decode</a></dfn>,
       <dfn id="external-webassembly-error"><a href="https://www.w3.org/TR/wasm-core-2/#embed-error">WebAssembly error</a></dfn>,
       <dfn id="external-webassembly-names" variants="WebAssembly name"><a href="https://www.w3.org/TR/wasm-core-2/#names%E2%91%A2">WebAssembly names</a></dfn>
     </dd>
-    <dt>WHATWG Encoding &lt;<a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>&gt;</dt>
+    <dt>WHATWG Encoding &lt;<a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>></dt>
     <dd>
       <dfn id="external-whatwg-encoding-utf-8-decode"><a href="https://encoding.spec.whatwg.org/#utf-8-decode">UTF-8 decode</a></dfn>
     </dd>
-    <dt>WHATWG <emu-not-ref>Fetch</emu-not-ref> &lt;<a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>&gt;</dt>
+    <dt>WHATWG <emu-not-ref>Fetch</emu-not-ref> &lt;<a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>></dt>
     <dd>
       <dfn id="external-whatwg-fetch"><a href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a></dfn>,
       <dfn id="external-whatwg-fetch-http-newline-byte"><a href="https://fetch.spec.whatwg.org/#http-newline-byte">HTTP newline byte</a></dfn>,
@@ -1372,12 +1546,12 @@ return lastURL;</code></pre>
       <dfn id="external-whatwg-fetch-request"><a href="https://fetch.spec.whatwg.org/#concept-request">request</a></dfn>,
       <dfn id="external-whatwg-fetch-request-url"><a href="https://fetch.spec.whatwg.org/#concept-request-url">request URL</a></dfn>
     </dd>
-    <dt>WHATWG Infra &lt;<a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>&gt;</dt>
+    <dt>WHATWG Infra &lt;<a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>></dt>
     <dd>
       <dfn id="external-whatwg-infra-byte-sequence"><a href="https://infra.spec.whatwg.org/#byte-sequence">byte sequence</a></dfn>,
       <dfn id="external-whatwg-infra-byte-sequence-prefix"><a href="https://infra.spec.whatwg.org/#byte-sequence-prefix">byte-sequence-prefix</a></dfn>
     </dd>
-    <dt>WHATWG <emu-not-ref>URL</emu-not-ref> &lt;<a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>&gt;</dt>
+    <dt>WHATWG <emu-not-ref>URL</emu-not-ref> &lt;<a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>></dt>
     <dd>
       <dfn id="external-whatwg-url-http-s-scheme"><a href="https://fetch.spec.whatwg.org/#http-scheme">HTTP(S) scheme</a></dfn>,
       <dfn id="external-whatwg-url-scheme"><a href="https://url.spec.whatwg.org/#concept-url-scheme">scheme</a></dfn>,
@@ -1391,37 +1565,37 @@ return lastURL;</code></pre>
   <h1>Bibliography</h1>
   <ol>
     <li>
-      IETF RFC 4648, <i>The Base16, Base32, and Base64 Data Encodings</i>, available at &lt;<a href="https://datatracker.ietf.org/doc/html/rfc4648">https://datatracker.ietf.org/doc/html/rfc4648</a>&gt;
+      IETF RFC 4648, <i>The Base16, Base32, and Base64 Data Encodings</i>, available at &lt;<a href="https://datatracker.ietf.org/doc/html/rfc4648">https://datatracker.ietf.org/doc/html/rfc4648</a>>
     </li>
     <li>
-      ECMA-262, <i>ECMAScript® Language Specification</i>, available at &lt;<a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a>&gt;
+      ECMA-262, <i>ECMAScript® Language Specification</i>, available at &lt;<a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a>>
     </li>
     <li>
-      ECMA-404, <i>The JSON Data Interchange Format</i>, available at &lt;<a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-404/">https://www.ecma-international.org/publications-and-standards/standards/ecma-404/</a>&gt;
+      ECMA-404, <i>The JSON Data Interchange Format</i>, available at &lt;<a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-404/">https://www.ecma-international.org/publications-and-standards/standards/ecma-404/</a>>
     </li>
     <li>
-      <i>WebAssembly Core Specification</i>, available at &lt;<a href="https://www.w3.org/TR/wasm-core-2/">https://www.w3.org/TR/wasm-core-2/</a>&gt;
+      <i>WebAssembly Core Specification</i>, available at &lt;<a href="https://www.w3.org/TR/wasm-core-2/">https://www.w3.org/TR/wasm-core-2/</a>>
     </li>
     <li>
-      WHATWG <i>Encoding</i>, available at &lt;<a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>&gt;
+      WHATWG <i>Encoding</i>, available at &lt;<a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>>
     </li>
     <li>
-      WHATWG <emu-not-ref><i>Fetch</i></emu-not-ref>, available at &lt;<a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>&gt;
+      WHATWG <emu-not-ref><i>Fetch</i></emu-not-ref>, available at &lt;<a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>>
     </li>
     <li>
-      WHATWG <i>Infra</i>, available at &lt;<a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>&gt;
+      WHATWG <i>Infra</i>, available at &lt;<a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>>
     </li>
     <li>
-      WHATWG <emu-not-ref><i>URL</i></emu-not-ref>, available at &lt;<a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>&gt;
+      WHATWG <emu-not-ref><i>URL</i></emu-not-ref>, available at &lt;<a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>>
     </li>
     <li>
-      <dfn id="biblio-give-your-eval-a-name">Give your eval a name with //@ sourceURL</dfn>, Firebug (2009), available at &lt;<a href="https://web.archive.org/web/20120814122523/http://blog.getfirebug.com/2009/08/11/give-your-eval-a-name-with-sourceurl/">http://blog.getfirebug.com/2009/08/11/give-your-eval-a-name-with-sourceurl/</a>&gt;
+      <dfn id="biblio-give-your-eval-a-name">Give your eval a name with //@ sourceURL</dfn>, Firebug (2009), available at &lt;<a href="https://web.archive.org/web/20120814122523/http://blog.getfirebug.com/2009/08/11/give-your-eval-a-name-with-sourceurl/">http://blog.getfirebug.com/2009/08/11/give-your-eval-a-name-with-sourceurl/</a>>
     </li>
     <li>
-      <dfn id="biblio-source-map-v2">Source Map Revision 2 Proposal</dfn>, John Lenz (2010), available at &lt;<a href="https://docs.google.com/document/d/1xi12LrcqjqIHTtZzrzZKmQ3lbTv9mKrN076UB-j3UZQ/">https://docs.google.com/document/d/1xi12LrcqjqIHTtZzrzZKmQ3lbTv9mKrN076UB-j3UZQ/</a>&gt;
+      <dfn id="biblio-source-map-v2">Source Map Revision 2 Proposal</dfn>, John Lenz (2010), available at &lt;<a href="https://docs.google.com/document/d/1xi12LrcqjqIHTtZzrzZKmQ3lbTv9mKrN076UB-j3UZQ/">https://docs.google.com/document/d/1xi12LrcqjqIHTtZzrzZKmQ3lbTv9mKrN076UB-j3UZQ/</a>>
     </li>
     <li>
-      <dfn id="biblio-vlq" variants="variable-length quantity">Variable-length quantity</dfn>, Wikipedia, available at &lt;<a href="https://en.wikipedia.org/wiki/Variable-length_quantity">https://en.wikipedia.org/wiki/Variable-length_quantity</a>&gt;
+      <dfn id="biblio-vlq" variants="variable-length quantity">Variable-length quantity</dfn>, Wikipedia, available at &lt;<a href="https://en.wikipedia.org/wiki/Variable-length_quantity">https://en.wikipedia.org/wiki/Variable-length_quantity</a>>
     </li>
   </ol>
 </emu-annex>
@@ -1432,3 +1606,4 @@ return lastURL;</code></pre>
   <p>The first edition of this specification was authored using <a href="https://speced.github.io/bikeshed/">Bikeshed</a>, a different plaintext source format based on HTML and Markdown.</p>
   <p>Pre-standard versions of this document were authored using Google Docs.</p>
 </emu-annex>
+</emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -241,8 +241,8 @@
     <h1>Grammar Notation</h1>
     <p>This specification follows the same grammar notation convention as defined by <a href="https://tc39.es/ecma262/#sec-grammar-notation">ECMA-262 (Grammar Notation)</a>, with the following caveats:</p>
     <ul>
-      <li>The terminal symbols of grammars in this specification are individual code points. They are more like ECMA-262 lexical and regexp grammars than the ECMA-262 syntactic grammar.</li>
-      <li>This specification does not use <a href="https://tc39.es/ecma262/#sec-grammatical-parameters">grammatical parameters</a> or <a href="https://tc39.es/ecma262/#sec-lookahead-restrictions">lookahead restrictions</a>, which keeps the grammars simpler.</li>
+      <li>The terminal symbols of grammars defined in this specification are individual code points. This is similar to ECMA-262's <a href="https://tc39.es/ecma262/#sec-lexical-and-regexp-grammars>lexical grammar</a>, rather than to ECMA-262's <a href="https://tc39.es/ecma262/#sec-syntactic-grammar">syntactic grammar</a>.</li>
+      <li>This specification does not use <a href="https://tc39.es/ecma262/#sec-grammatical-parameters">grammatical parameters</a> or <a href="https://tc39.es/ecma262/#sec-lookahead-restrictions">lookahead restrictions</a>, to reduce the grammar definitions complexity.</li>
     </ul>
   </emu-clause>
 </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -945,7 +945,7 @@
         <emu-alg>
           1. Let _relativeName_ be the VLQSignedValue of |Vlq|.
           1. Set _state_.[[NameIndex]] to _state_.[[NameIndex]] + _relativeName_.
-          1. If _state_.[[NameIndex]] &lt; 0 or _state_[[NameIndex]] ≥ the number of elements of _sources_, optionally report an error.
+          1. If _state_.[[NameIndex]] &lt; 0 or _state_.[[NameIndex]] ≥ the number of elements of _sources_, optionally report an error.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -311,6 +311,9 @@
         1. Let _value_ be floor(_unsigned_ / 2).
         1. If _value_ is 0 and _sign_ is -1, return -2<sup>31</sup>.
         1. If _value_ is ≥ 2<sup>31</sup>, throw an error.
+          <emu-note>
+            The check is required here as _unsigned_ is the VLQUnsignedValue of |VlqDigitList|, not of |Vlq|.
+          </emu-note>
         1. Return _sign_ × _value_.
       </emu-alg>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -333,7 +333,7 @@
       </emu-grammar>
       <emu-alg>
         1. Let _value_ be the VLQUnsignedValue of |VlqDigitList|.
-        1. If _value_ is ≥ 2<sup>31</sup>, throw an error.
+        1. If _value_ is ≥ 2<sup>32</sup>, throw an error.
         1. Return _value_.
       </emu-alg>
       <emu-grammar>


### PR DESCRIPTION
Draft that changes VLQ and mappings to use grammar plus "syntax-directed operations" for decoding rather than a pure algorithmic approach.

Only uploaded so we have a preview for discussion.

Preview: https://szuend.github.io/source-map/branch/mappings-grammar/#sec-mappings