### PR TITLE
Fix sourceRoot decoding

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1080,9 +1080,8 @@
         1. Let _sourcesContentCount_ be the the number of elements in _sourcesContent_.
         1. Let _sourceUrlPrefix_ be *""*.
         1. If _sourceRoot_ ≠ *null*, then
-          1. If _sourceRoot_ contains the code point U+002F (SOLIDUS), then
-            1. Let _idx_ be the index of the last occurrence of U+002F (SOLIDUS) in _sourceRoot_.
-            1. Set _sourceUrlPrefix_ to the substring of _sourceRoot_ from 0 to _idx_ + 1.
+          1. If _sourceRoot_ ends with the code point U+002F (SOLIDUS), then
+            1. Set _sourceUrlPrefix_ to _sourceRoot_.
           1. Else,
             1. Set _sourceUrlPrefix_ to the string-concatenation of _sourceRoot_ and *"/"*.
         1. Let _index_ be 0.


### PR DESCRIPTION
This matches impl behavior for `sourceRoot`. If set, it's treated as a path, and if it does not end with a `/`, it is appended with one:

- [Chrome](https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/core/sdk/SourceMap.ts;l=486-492;drc=6ca4ad9f4aac1de91c8b5095b8fdb558ad9e7c5e)
- [Mozilla](https://github.com/mozilla/source-map/blob/3cb92cc3b73bfab27c146bae4ef2bc09dbb4e5ed/lib/util.js#L440)
- [trace-mapping](https://github.com/jridgewell/trace-mapping/blob/5a658b10d9b6dea9c614ff545ca9c4df895fee9e/src/resolve.ts#L10-L13)

I think the confusion here came from `baseURL` (the map file's URL), which **is** filename trimmed.