### PR TITLE
fix: Improve 'emu-note' text contrast w/ dark mode

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -37,6 +37,7 @@
   }
 
   emu-note[issue], emu-note[example] {
+    color: black;
     counter-increment: var(--note-type);
     border-left-color: var(--note-border-color);
     background-color: var(--note-background-color);


### PR DESCRIPTION
Now that ecmarkup supports dark mode, the emu-notes cause a bit of a readability issue (in that they're impossible to read) as they set light backgrounds which contrast poorly with the page-wide foreground color. Setting the foreground color to black for both seems appropriate.

Image, for reference:

![Shows the current styling of example & issue notes, using white text on a very light background so that text is impossible to read](https://github.com/user-attachments/assets/34786aeb-d82b-4c95-b7bf-d65a5df0f832)

> https://tc39.es/ecma426/#sec-linking-inline

The hljs setup will need to be adjusted yet too, though that can be done separately by someone else. Seems a bit more involved and would need some playing with, whilst this is just a drive-by fix.