### PR TITLE
Editorial: use 0b for binary representation

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -280,10 +280,10 @@
   <p>A <dfn id="sec-base64-vlq">base64 VLQ</dfn> is a <emu-xref href="#sec-references-informative">base64</emu-xref>-encoded variable-length quantity, where the most significant bit (the 6th bit) is used as the continuation bit, and the "digits" are encoded into the string least significant first, and where the least significant bit of the first digit is used as the sign bit.</p>
   <emu-note>The values that can be represented by the base64 VLQ encoding are limited to 32-bit quantities until some use case for larger values is presented. This means that values exceeding 32-bits are invalid and implementations may reject them. The sign bit is counted towards the limit, but the continuation bits are not.</emu-note>
   <emu-note example>
-    The string `"iB"` represents a base64 VLQ with two digits. The first digit `"i"` encodes the bit pattern `0x100010`, which has a continuation bit of `1` (the VLQ continues), a sign bit of `0` (non-negative), and the value bits `0x0001`. The second digit `B` encodes the bit pattern `0x000001`, which has a continuation bit of `0`, no sign bit, and value bits `0x00001`. The decoding of this VLQ string is the number 17.
+    The string `"iB"` represents a base64 VLQ with two digits. The first digit `"i"` encodes the bit pattern `0b100010`, which has a continuation bit of `1` (the VLQ continues), a sign bit of `0` (non-negative), and the value bits `0b0001`. The second digit `B` encodes the bit pattern `0b000001`, which has a continuation bit of `0`, no sign bit, and value bits `0b00001`. The decoding of this VLQ string is the number 17.
   </emu-note>
   <emu-note example>
-    The string `"V"` represents a base64 VLQ with one digit. The digit `"V"` encodes the bit pattern `0x010101`, which has a continuation bit of `0` (no continuation), a sign bit of `1` (negative), and the value bits `0x1010`. The decoding of this VLQ string is the number -10.
+    The string `"V"` represents a base64 VLQ with one digit. The digit `"V"` encodes the bit pattern `0b010101`, which has a continuation bit of `0` (no continuation), a sign bit of `1` (negative), and the value bits `0b1010`. The decoding of this VLQ string is the number -10.
   </emu-note>
   <p>A base64 VLQ adheres to the following lexical grammar:</p>
 


### PR DESCRIPTION
Fix #416